### PR TITLE
fix a numpy link error

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Then update your PYTHONPATH variable to have it visible for python.
 In your .bashrc, it would look like :
 export PYTHONPATH=/My/complete/path/to/the/install/dir:$PYTHONPATH
 
-and I am too lazy to find out how to install this in the root of python (it does not work yet for me)
+### Install to the python root directory
+
+```
+meson setup builddir --prefix=$(python3 -c "import site; print(site.getsitepackages()[0])")
+meson compile -C builddir
+meson install -C builddir
+```
 
 

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('okada4py', 'cpp', version : '1.0.1', default_options : ['cpp_std=c++11'
 
 py3 = import('python').find_installation('python')
 
-numpy_include = run_command(py3, '-c', 'import numpy; print(numpy.get_include()+"/numpy")').stdout().strip()
+numpy_include = run_command(py3, '-c', 'import numpy; print(numpy.get_include())').stdout().strip()
 
 src = ['src/dc3d.cpp', 'src/disloc3d.cpp', 'src/okada92_py3.cpp']
 

--- a/src/okada92_py3.cpp
+++ b/src/okada92_py3.cpp
@@ -8,7 +8,7 @@ extern "C" {
 #include "dc3d.h"
 #include "disloc3d.h"
 #include "Python.h"
-#include "arrayobject.h"
+#include "numpy/arrayobject.h"
 
 static PyObject *py_Okada(PyObject *self, PyObject *args)
 {


### PR DESCRIPTION
Thanks for the meson update! However, I met a numpy link error like this one, 

https://github.com/numpy/numpy/issues/26854

It was suggested there that the solution is to use numpy.get_include() as the path while using "numpy/xxx.h" in c source files. 